### PR TITLE
Add disk caching (via optional `lightly` gem)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://gem.coop"
 
 gemspec
+
+gem "lightly"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ be set via ENV or `SlackLine.configure`:
 * `per_thread_delay` or `SLACK_LINE_PER_THREAD_DELAY` is a float as
   well - SlackLine will `sleep` for this duration after each _thread_
   is posted, and after each non-thread message is posted.
+* `cache_path` or `SLACK_LINE_CACHE_PATH` - a directory path for
+  disk-caching the users and groups lists fetched from the Slack API.
+  When set, SlackLine will use the [lightly](https://github.com/DannyBen/lightly)
+  gem to cache results to disk, which avoids redundant API calls across
+  separate runs. Requires `lightly` to be installed as an optional
+  dependency - if it is not available, a `DiskCaching::NoLightly` error
+  will be raised at runtime.
+* `cache_duration` or `SLACK_LINE_CACHE_DURATION` - how long cached
+  data remains valid (default `"15m"`). Accepts a plain integer number
+  of seconds, or a number followed by a unit suffix: `s` (seconds),
+  `m` (minutes), `h` (hours), or `d` (days). For example: `"30m"`,
+  `"2h"`, `"1d"`, or `"900"`.
 
 You can just set those via the environment variables, but you can also
 set them on the singleton configuration object:
@@ -92,6 +104,8 @@ SlackLine.configure do |config|
   config.default_channel = "#ci-flow"
   config.per_message_delay = 0.2
   config.per_thread_delay = 2.0
+  config.cache_path = "/tmp/slack_line_cache"
+  config.cache_duration = "1h"
 end
 ```
 

--- a/lib/slack_line/cli/slack_line_message.rb
+++ b/lib/slack_line/cli/slack_line_message.rb
@@ -24,7 +24,7 @@ module SlackLine
 
       def options
         return @options if defined?(@options)
-        opts = {post_to: nil, append: nil, update: nil, message_number: nil, save: nil, slack_token: nil, look_up_users: nil, bot_name: nil, backoff: nil}
+        opts = {post_to: nil, append: nil, update: nil, message_number: nil, save: nil, slack_token: nil, look_up_users: nil, bot_name: nil, backoff: nil, cache_path: nil, cache_duration: nil}
         remaining = option_parser(opts).parse(@argv.dup)
         if remaining.empty?
           opts[:dsl] = read_stdin
@@ -37,7 +37,7 @@ module SlackLine
 
       def configuration
         return @configuration if defined?(@configuration)
-        cfg_opts = options.slice(:slack_token, :look_up_users, :bot_name, :backoff).compact
+        cfg_opts = options.slice(:slack_token, :look_up_users, :bot_name, :backoff, :cache_path, :cache_duration).compact
         @configuration = Configuration.new(nil, **cfg_opts)
       end
 
@@ -56,6 +56,8 @@ module SlackLine
           parser.on("-m", "--message-number N", Integer) { |n| opts[:message_number] = n }
           parser.on("-s", "--save PATH") { |p| opts[:save] = p }
           parser.on("--no-backoff") { opts[:backoff] = false }
+          parser.on("--cache-path PATH") { |p| opts[:cache_path] = p }
+          parser.on("--cache-duration DURATION") { |d| opts[:cache_duration] = d }
         end
       end
 

--- a/lib/slack_line/cli/slack_line_message.rb
+++ b/lib/slack_line/cli/slack_line_message.rb
@@ -20,6 +20,8 @@ module SlackLine
         else
           run_preview
         end
+      rescue DiskCaching::NoLightly, Configuration::InvalidValue => e
+        raise ExitException, e.message
       end
 
       def options

--- a/lib/slack_line/cli/slack_line_thread.rb
+++ b/lib/slack_line/cli/slack_line_thread.rb
@@ -20,7 +20,7 @@ module SlackLine
 
       def options
         return @options if defined?(@options)
-        opts = {post_to: nil, save: nil, slack_token: nil, look_up_users: nil, bot_name: nil, backoff: nil}
+        opts = {post_to: nil, save: nil, slack_token: nil, look_up_users: nil, bot_name: nil, backoff: nil, cache_path: nil, cache_duration: nil}
         remaining = option_parser(opts).parse(@argv.dup)
         if remaining.empty?
           opts[:dsl] = read_stdin
@@ -32,7 +32,7 @@ module SlackLine
 
       def configuration
         return @configuration if defined?(@configuration)
-        cfg_opts = options.slice(:slack_token, :look_up_users, :bot_name, :backoff).compact
+        cfg_opts = options.slice(:slack_token, :look_up_users, :bot_name, :backoff, :cache_path, :cache_duration).compact
         @configuration = Configuration.new(nil, **cfg_opts)
       end
 
@@ -48,6 +48,8 @@ module SlackLine
           parser.on("-p", "--post-to TARGET") { |t| opts[:post_to] = t }
           parser.on("-s", "--save PATH") { |p| opts[:save] = p }
           parser.on("--no-backoff") { opts[:backoff] = false }
+          parser.on("--cache-path PATH") { |p| opts[:cache_path] = p }
+          parser.on("--cache-duration DURATION") { |d| opts[:cache_duration] = d }
         end
       end
 

--- a/lib/slack_line/cli/slack_line_thread.rb
+++ b/lib/slack_line/cli/slack_line_thread.rb
@@ -16,6 +16,8 @@ module SlackLine
         else
           run_preview
         end
+      rescue DiskCaching::NoLightly, Configuration::InvalidValue => e
+        raise ExitException, e.message
       end
 
       def options

--- a/lib/slack_line/client.rb
+++ b/lib/slack_line/client.rb
@@ -16,8 +16,8 @@ module SlackLine
 
     def thread(*messages, &dsl_block) = Thread.new(*messages, client: self, &dsl_block)
 
-    memoize def users = Users.new(slack_client:)
+    memoize def users = Users.new(client: self)
 
-    memoize def groups = Groups.new(slack_client:)
+    memoize def groups = Groups.new(client: self)
   end
 end

--- a/lib/slack_line/configuration.rb
+++ b/lib/slack_line/configuration.rb
@@ -1,11 +1,18 @@
 module SlackLine
   class Configuration
+    include Memoization
+
+    InvalidValue = Class.new(Error)
+
     attr_accessor :slack_token,
       :look_up_users, :bot_name, :default_channel,
       :per_message_delay, :per_thread_delay,
       :backoff, :cache_path
+    attr_writer :cache_duration
 
     alias_method :look_up_users?, :look_up_users
+
+    memoize def cache_duration = parse_duration(@cache_duration.to_s)
 
     DEFAULTS = {
       slack_token: nil,
@@ -15,7 +22,8 @@ module SlackLine
       per_message_delay: 0.0,
       per_thread_delay: 0.0,
       backoff: true,
-      cache_path: nil
+      cache_path: nil,
+      cache_duration: "15m"
     }.freeze
 
     def initialize(base_config = nil, **overrides)
@@ -30,6 +38,7 @@ module SlackLine
       @per_thread_delay = cascade(:per_thread_delay, "SLACK_LINE_PER_THREAD_DELAY", :float)
       @backoff = cascade(:backoff, "SLACK_LINE_NO_BACKOFF", :inverse_boolean)
       @cache_path = cascade(:cache_path, "SLACK_LINE_CACHE_PATH", :string)
+      @cache_duration = cascade(:cache_duration, "SLACK_LINE_CACHE_DURATION", :string)
     end
 
     private
@@ -58,6 +67,16 @@ module SlackLine
       else
         value
       end
+    end
+
+    DURATION_MULTIPLIERS = {"s" => 1, "m" => 60, "h" => 3600, "d" => 86400}.freeze
+
+    def parse_duration(value)
+      match = value.match(/\A(\d+)([smhd])?\z/)
+      raise(InvalidValue, "Invalid duration: #{value.inspect}") unless match
+
+      digits, unit = match.captures
+      digits.to_i * (DURATION_MULTIPLIERS[unit] || 1)
     end
   end
 end

--- a/lib/slack_line/configuration.rb
+++ b/lib/slack_line/configuration.rb
@@ -69,14 +69,14 @@ module SlackLine
       end
     end
 
-    DURATION_MULTIPLIERS = {"s" => 1, "m" => 60, "h" => 3600, "d" => 86400}.freeze
+    DURATION_MULTIPLIERS = {s: 1, m: 60, h: 3600, d: 86400}.freeze
 
     def parse_duration(value)
       match = value.match(/\A(\d+)([smhd])?\z/)
       raise(InvalidValue, "Invalid duration: #{value.inspect}") unless match
 
       digits, unit = match.captures
-      digits.to_i * (DURATION_MULTIPLIERS[unit] || 1)
+      digits.to_i * DURATION_MULTIPLIERS.fetch(unit&.to_sym, 1)
     end
   end
 end

--- a/lib/slack_line/configuration.rb
+++ b/lib/slack_line/configuration.rb
@@ -3,7 +3,7 @@ module SlackLine
     attr_accessor :slack_token,
       :look_up_users, :bot_name, :default_channel,
       :per_message_delay, :per_thread_delay,
-      :backoff
+      :backoff, :cache_path
 
     alias_method :look_up_users?, :look_up_users
 
@@ -14,7 +14,8 @@ module SlackLine
       default_channel: nil,
       per_message_delay: 0.0,
       per_thread_delay: 0.0,
-      backoff: true
+      backoff: true,
+      cache_path: nil
     }.freeze
 
     def initialize(base_config = nil, **overrides)
@@ -28,6 +29,7 @@ module SlackLine
       @per_message_delay = cascade(:per_message_delay, "SLACK_LINE_PER_MESSAGE_DELAY", :float)
       @per_thread_delay = cascade(:per_thread_delay, "SLACK_LINE_PER_THREAD_DELAY", :float)
       @backoff = cascade(:backoff, "SLACK_LINE_NO_BACKOFF", :inverse_boolean)
+      @cache_path = cascade(:cache_path, "SLACK_LINE_CACHE_PATH", :string)
     end
 
     private

--- a/lib/slack_line/disk_caching.rb
+++ b/lib/slack_line/disk_caching.rb
@@ -1,3 +1,9 @@
+begin
+  require "lightly"
+rescue LoadError
+  # optional dependency
+end
+
 module SlackLine
   module DiskCaching
     NoLightly = Class.new(Error)

--- a/lib/slack_line/disk_caching.rb
+++ b/lib/slack_line/disk_caching.rb
@@ -1,0 +1,12 @@
+module SlackLine
+  module DiskCaching
+    NoLightly = Class.new(Error)
+
+    def cached(config:, key:, &block)
+      return yield if config.cache_path.nil?
+      raise(NoLightly, "The 'lightly' gem is required for disk caching") unless defined?(Lightly)
+
+      Lightly.new(dir: config.cache_path, life: config.cache_duration).get(key) { yield }
+    end
+  end
+end

--- a/lib/slack_line/groups.rb
+++ b/lib/slack_line/groups.rb
@@ -2,8 +2,8 @@ module SlackLine
   class Groups
     include Memoization
 
-    def initialize(slack_client:)
-      @slack_client = slack_client
+    def initialize(client:)
+      @client = client
     end
 
     memoize def all = fetch_groups
@@ -14,7 +14,9 @@ module SlackLine
 
     private
 
-    attr_reader :slack_client
+    attr_reader :client
+
+    def slack_client = client.slack_client
 
     memoize def fetch_groups
       slack_client.usergroups_list.usergroups || []

--- a/lib/slack_line/groups.rb
+++ b/lib/slack_line/groups.rb
@@ -1,12 +1,15 @@
 module SlackLine
   class Groups
     include Memoization
+    include DiskCaching
 
     def initialize(client:)
       @client = client
     end
 
-    memoize def all = fetch_groups
+    memoize def all
+      cached(config: client.configuration, key: "groups_all") { fetch_groups }
+    end
 
     def find(handle:)
       groups_by_handle[handle.downcase]

--- a/lib/slack_line/users.rb
+++ b/lib/slack_line/users.rb
@@ -2,8 +2,8 @@ module SlackLine
   class Users
     include Memoization
 
-    def initialize(slack_client:)
-      @slack_client = slack_client
+    def initialize(client:)
+      @client = client
     end
 
     memoize def all = all_users.reject(&:deleted).reject(&:is_bot)
@@ -14,7 +14,9 @@ module SlackLine
 
     private
 
-    attr_reader :slack_client
+    attr_reader :client
+
+    def slack_client = client.slack_client
 
     def fetch_page(cursor: nil)
       params = {limit: 200}

--- a/lib/slack_line/users.rb
+++ b/lib/slack_line/users.rb
@@ -1,12 +1,15 @@
 module SlackLine
   class Users
     include Memoization
+    include DiskCaching
 
     def initialize(client:)
       @client = client
     end
 
-    memoize def all = all_users.reject(&:deleted).reject(&:is_bot)
+    memoize def all
+      cached(config: client.configuration, key: "users_all") { all_users.reject(&:deleted).reject(&:is_bot) }
+    end
 
     def find(display_name:)
       users_by_display_name[display_name.downcase]

--- a/spec/slack_line/cli/slack_line_message_spec.rb
+++ b/spec/slack_line/cli/slack_line_message_spec.rb
@@ -244,6 +244,26 @@ RSpec.describe SlackLine::Cli::SlackLineMessage do
     end
   end
 
+  describe "with --cache-path" do
+    let(:argv) { %w[--slack-token fake-token --cache-path /tmp/cache Hello] }
+
+    without_env("SLACK_LINE_CACHE_PATH")
+
+    it "sets cache_path in configuration" do
+      expect(cli.configuration.cache_path).to eq("/tmp/cache")
+    end
+  end
+
+  describe "with --cache-duration" do
+    let(:argv) { %w[--slack-token fake-token --cache-duration 30m Hello] }
+
+    without_env("SLACK_LINE_CACHE_DURATION")
+
+    it "sets cache_duration in configuration" do
+      expect(cli.configuration.cache_duration).to eq(1800)
+    end
+  end
+
   describe "DSL mode (no content args)" do
     context "with --update" do
       let(:argv) { %w[--slack-token fake-token --update /tmp/msg.json] }

--- a/spec/slack_line/cli/slack_line_message_spec.rb
+++ b/spec/slack_line/cli/slack_line_message_spec.rb
@@ -254,6 +254,26 @@ RSpec.describe SlackLine::Cli::SlackLineMessage do
     end
   end
 
+  describe "when DiskCaching::NoLightly is raised" do
+    let(:argv) { %w[--slack-token fake-token Hello] }
+
+    before { allow(cli).to receive(:run_preview).and_raise(SlackLine::DiskCaching::NoLightly, "lightly gem required") }
+
+    it "raises ExitException" do
+      expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, "lightly gem required")
+    end
+  end
+
+  describe "when Configuration::InvalidValue is raised" do
+    let(:argv) { %w[--slack-token fake-token Hello] }
+
+    before { allow(cli).to receive(:run_preview).and_raise(SlackLine::Configuration::InvalidValue, "invalid duration") }
+
+    it "raises ExitException" do
+      expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, "invalid duration")
+    end
+  end
+
   describe "with --cache-duration" do
     let(:argv) { %w[--slack-token fake-token --cache-duration 30m Hello] }
 

--- a/spec/slack_line/cli/slack_line_thread_spec.rb
+++ b/spec/slack_line/cli/slack_line_thread_spec.rb
@@ -86,6 +86,26 @@ RSpec.describe SlackLine::Cli::SlackLineThread do
     end
   end
 
+  describe "when DiskCaching::NoLightly is raised" do
+    let(:argv) { %w[--slack-token fake-token Hello] }
+
+    before { allow(cli).to receive(:run_preview).and_raise(SlackLine::DiskCaching::NoLightly, "lightly gem required") }
+
+    it "raises ExitException" do
+      expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, "lightly gem required")
+    end
+  end
+
+  describe "when Configuration::InvalidValue is raised" do
+    let(:argv) { %w[--slack-token fake-token Hello] }
+
+    before { allow(cli).to receive(:run_preview).and_raise(SlackLine::Configuration::InvalidValue, "invalid duration") }
+
+    it "raises ExitException" do
+      expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, "invalid duration")
+    end
+  end
+
   describe "with --cache-duration" do
     let(:argv) { %w[--slack-token fake-token --cache-duration 30m Hello] }
 

--- a/spec/slack_line/cli/slack_line_thread_spec.rb
+++ b/spec/slack_line/cli/slack_line_thread_spec.rb
@@ -76,6 +76,26 @@ RSpec.describe SlackLine::Cli::SlackLineThread do
     end
   end
 
+  describe "with --cache-path" do
+    let(:argv) { %w[--slack-token fake-token --cache-path /tmp/cache Hello] }
+
+    without_env("SLACK_LINE_CACHE_PATH")
+
+    it "sets cache_path in configuration" do
+      expect(cli.configuration.cache_path).to eq("/tmp/cache")
+    end
+  end
+
+  describe "with --cache-duration" do
+    let(:argv) { %w[--slack-token fake-token --cache-duration 30m Hello] }
+
+    without_env("SLACK_LINE_CACHE_DURATION")
+
+    it "sets cache_duration in configuration" do
+      expect(cli.configuration.cache_duration).to eq(1800)
+    end
+  end
+
   describe "DSL mode (no content args)" do
     let(:argv) { %w[--slack-token fake-token --post-to C12345678] }
 

--- a/spec/slack_line/configuration_spec.rb
+++ b/spec/slack_line/configuration_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe SlackLine::Configuration do
     "SLACK_LINE_PER_MESSAGE_DELAY",
     "SLACK_LINE_PER_THREAD_DELAY",
     "SLACK_LINE_NO_BACKOFF",
-    "SLACK_LINE_CACHE_PATH"
+    "SLACK_LINE_CACHE_PATH",
+    "SLACK_LINE_CACHE_DURATION"
   )
 
   let(:base_config) { nil }
@@ -27,6 +28,7 @@ RSpec.describe SlackLine::Configuration do
       expect(configuration.per_thread_delay).to be_within(0.001).of(0.0)
       expect(configuration.backoff).to be true
       expect(configuration.cache_path).to be_nil
+      expect(configuration.cache_duration).to eq(900)
     end
   end
 
@@ -40,7 +42,8 @@ RSpec.describe SlackLine::Configuration do
         per_message_delay: 1.0,
         per_thread_delay: 2.0,
         backoff: false,
-        cache_path: "/tmp/cache"
+        cache_path: "/tmp/cache",
+        cache_duration: "5m"
       )
     end
 
@@ -53,6 +56,7 @@ RSpec.describe SlackLine::Configuration do
       expect(configuration.per_thread_delay).to be_within(0.001).of(2.0)
       expect(configuration.backoff).to be false
       expect(configuration.cache_path).to eq("/tmp/cache")
+      expect(configuration.cache_duration).to eq(300)
     end
 
     context "AND overrides" do
@@ -80,7 +84,8 @@ RSpec.describe SlackLine::Configuration do
         per_message_delay: 0.5,
         per_thread_delay: 1.5,
         backoff: false,
-        cache_path: "/tmp/override_cache"
+        cache_path: "/tmp/override_cache",
+        cache_duration: "1m"
       }
     end
 
@@ -93,6 +98,7 @@ RSpec.describe SlackLine::Configuration do
       expect(configuration.per_thread_delay).to be_within(0.001).of(1.5)
       expect(configuration.backoff).to be false
       expect(configuration.cache_path).to eq("/tmp/override_cache")
+      expect(configuration.cache_duration).to eq(60)
     end
   end
 
@@ -152,6 +158,33 @@ RSpec.describe SlackLine::Configuration do
 
     it "uses the env var as the cache path" do
       expect(configuration.cache_path).to eq("/tmp/slack_cache")
+    end
+  end
+
+  context "when SLACK_LINE_CACHE_DURATION is set" do
+    def self.it_parses_duration(input, as:)
+      context "to #{input.inspect}" do
+        with_env("SLACK_LINE_CACHE_DURATION" => input)
+
+        it "parses it as #{as} seconds" do
+          expect(configuration.cache_duration).to eq(as)
+        end
+      end
+    end
+
+    it_parses_duration "1800", as: 1800
+    it_parses_duration "90s", as: 90
+    it_parses_duration "15m", as: 900
+    it_parses_duration "2h", as: 7200
+    it_parses_duration "1d", as: 86400
+
+    context "to an invalid value" do
+      with_env("SLACK_LINE_CACHE_DURATION" => "15minutes")
+
+      it "raises Configuration::InvalidValue" do
+        expect { configuration.cache_duration }
+          .to raise_error(SlackLine::Configuration::InvalidValue)
+      end
     end
   end
 end

--- a/spec/slack_line/configuration_spec.rb
+++ b/spec/slack_line/configuration_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe SlackLine::Configuration do
     "SLACK_LINE_DEFAULT_CHANNEL",
     "SLACK_LINE_PER_MESSAGE_DELAY",
     "SLACK_LINE_PER_THREAD_DELAY",
-    "SLACK_LINE_NO_BACKOFF"
+    "SLACK_LINE_NO_BACKOFF",
+    "SLACK_LINE_CACHE_PATH"
   )
 
   let(:base_config) { nil }
@@ -25,6 +26,7 @@ RSpec.describe SlackLine::Configuration do
       expect(configuration.per_message_delay).to be_within(0.001).of(0.0)
       expect(configuration.per_thread_delay).to be_within(0.001).of(0.0)
       expect(configuration.backoff).to be true
+      expect(configuration.cache_path).to be_nil
     end
   end
 
@@ -37,7 +39,8 @@ RSpec.describe SlackLine::Configuration do
         default_channel: "#base-channel",
         per_message_delay: 1.0,
         per_thread_delay: 2.0,
-        backoff: false
+        backoff: false,
+        cache_path: "/tmp/cache"
       )
     end
 
@@ -49,6 +52,7 @@ RSpec.describe SlackLine::Configuration do
       expect(configuration.per_message_delay).to be_within(0.001).of(1.0)
       expect(configuration.per_thread_delay).to be_within(0.001).of(2.0)
       expect(configuration.backoff).to be false
+      expect(configuration.cache_path).to eq("/tmp/cache")
     end
 
     context "AND overrides" do
@@ -75,7 +79,8 @@ RSpec.describe SlackLine::Configuration do
         default_channel: "#override-channel",
         per_message_delay: 0.5,
         per_thread_delay: 1.5,
-        backoff: false
+        backoff: false,
+        cache_path: "/tmp/override_cache"
       }
     end
 
@@ -87,6 +92,7 @@ RSpec.describe SlackLine::Configuration do
       expect(configuration.per_message_delay).to be_within(0.001).of(0.5)
       expect(configuration.per_thread_delay).to be_within(0.001).of(1.5)
       expect(configuration.backoff).to be false
+      expect(configuration.cache_path).to eq("/tmp/override_cache")
     end
   end
 
@@ -138,6 +144,14 @@ RSpec.describe SlackLine::Configuration do
 
     it "leaves backoff enabled" do
       expect(configuration.backoff).to be true
+    end
+  end
+
+  context "when SLACK_LINE_CACHE_PATH is set" do
+    with_env("SLACK_LINE_CACHE_PATH" => "/tmp/slack_cache")
+
+    it "uses the env var as the cache path" do
+      expect(configuration.cache_path).to eq("/tmp/slack_cache")
     end
   end
 end

--- a/spec/slack_line/disk_caching_spec.rb
+++ b/spec/slack_line/disk_caching_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe SlackLine::DiskCaching do
+  let(:test_class) do
+    Class.new do
+      include SlackLine::DiskCaching
+    end
+  end
+
+  let(:instance) { test_class.new }
+
+  def config(cache_path:, cache_duration: 900)
+    instance_double(SlackLine::Configuration, cache_path:, cache_duration:)
+  end
+
+  describe "#cached" do
+    context "when config.cache_path is nil" do
+      it "yields the block directly" do
+        result = instance.cached(config: config(cache_path: nil), key: "test") { "value" }
+        expect(result).to eq("value")
+      end
+    end
+
+    context "when config.cache_path is provided" do
+      context "and Lightly is not defined" do
+        it "raises DiskCaching::NoLightly" do
+          expect { instance.cached(config: config(cache_path: "/tmp/cache"), key: "test") { "value" } }
+            .to raise_error(SlackLine::DiskCaching::NoLightly)
+        end
+      end
+
+      context "and Lightly is defined" do
+        let(:fake_lightly_cache) { instance_double("FakeLightly") }
+
+        before do
+          stub_const("Lightly", Class.new do
+            def initialize(dir:, life:)
+              @dir = dir
+              @life = life
+            end
+          end)
+          allow(Lightly).to receive(:new).and_return(fake_lightly_cache)
+          allow(fake_lightly_cache).to receive(:get).with("the-key") { |&b| b.call }
+        end
+
+        it "instantiates Lightly with the cache_path and cache_duration from config" do
+          instance.cached(config: config(cache_path: "/tmp/cache", cache_duration: 300), key: "the-key") { "value" }
+          expect(Lightly).to have_received(:new).with(dir: "/tmp/cache", life: 300)
+        end
+
+        it "returns the result of the block" do
+          result = instance.cached(config: config(cache_path: "/tmp/cache"), key: "the-key") { "value" }
+          expect(result).to eq("value")
+        end
+      end
+    end
+  end
+end

--- a/spec/slack_line/disk_caching_spec.rb
+++ b/spec/slack_line/disk_caching_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe SlackLine::DiskCaching do
 
     context "when config.cache_path is provided" do
       context "and Lightly is not defined" do
+        before { hide_const("Lightly") }
+
         it "raises DiskCaching::NoLightly" do
           expect { instance.cached(config: config(cache_path: "/tmp/cache"), key: "test") { "value" } }
             .to raise_error(SlackLine::DiskCaching::NoLightly)

--- a/spec/slack_line/groups_spec.rb
+++ b/spec/slack_line/groups_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe SlackLine::Groups do
+  let(:configuration) { instance_double(SlackLine::Configuration, cache_path: nil) }
   let(:slack_client) { instance_double(Slack::Web::Client) }
-  let(:client) { instance_double(SlackLine::Client, slack_client:) }
+  let(:client) { instance_double(SlackLine::Client, slack_client:, configuration:) }
   subject(:groups) { described_class.new(client:) }
 
   before { allow(slack_client).to receive(:usergroups_list).and_return(response) }

--- a/spec/slack_line/groups_spec.rb
+++ b/spec/slack_line/groups_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe SlackLine::Groups do
-  let!(:slack_client) { stubbed_instantiation(Slack::Web::Client) }
-  subject(:groups) { described_class.new(slack_client:) }
+  let(:slack_client) { instance_double(Slack::Web::Client) }
+  let(:client) { instance_double(SlackLine::Client, slack_client:) }
+  subject(:groups) { described_class.new(client:) }
 
   before { allow(slack_client).to receive(:usergroups_list).and_return(response) }
   let(:response) do

--- a/spec/slack_line/users_spec.rb
+++ b/spec/slack_line/users_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe SlackLine::Users do
+  let(:configuration) { instance_double(SlackLine::Configuration, cache_path: nil) }
   let(:slack_client) { instance_double(Slack::Web::Client) }
-  let(:client) { instance_double(SlackLine::Client, slack_client:) }
+  let(:client) { instance_double(SlackLine::Client, slack_client:, configuration:) }
   subject(:users) { described_class.new(client:) }
 
   before { allow(slack_client).to receive(:users_list).and_return(response_one, response_two) }

--- a/spec/slack_line/users_spec.rb
+++ b/spec/slack_line/users_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe SlackLine::Users do
-  let!(:slack_client) { stubbed_instantiation(Slack::Web::Client) }
-  subject(:users) { described_class.new(slack_client:) }
+  let(:slack_client) { instance_double(Slack::Web::Client) }
+  let(:client) { instance_double(SlackLine::Client, slack_client:) }
+  subject(:users) { described_class.new(client:) }
 
   before { allow(slack_client).to receive(:users_list).and_return(response_one, response_two) }
   let(:response_one) do


### PR DESCRIPTION
* Add `cache_path` and `cache_duration` to Configuration (and env and cli args)
  - if `cache_path` is supplied, it turns _on_ disk-caching (default is nil)
  - `cache_duration` can be a plain integer (seconds) or an integer followed by "s", "m", "h", or "d", for time units (seconds, minutes, hours, days). For example "60m" is the same as "1h" or "3600". This controls how long the cache should be good for - the default is 15 minutes.
* Add DiskCaching to Users/Groups
  - need to inject the SlackLine::Client instead of the Slack::Api::Client into both, so I could access the Configuration
  - wrap the 'all' method for each in `cached` (the others are all defined efficiently in terms of that)
* Update the README to document the new flags and behavior.