### PR TITLE
Slack line stateful thread cli tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ SlackLine.configure do |config|
 end
 ```
 
-## Multiple Configurations
+### Multiple Configurations
 
 If you're working in a context where you need to support multiple
 SlackLine configurations, don't worry! The singleton central config is
@@ -135,6 +135,126 @@ BAR_SLACK = SlackLine::Client.new(default_channel: "#team-bar", bot_name: "BarBo
 BAR_SLACK.thread("Message 1", "Message 2").post
 BAR_SLACK.message("Message 3", to: "#bar-team-3").post
 ```
+
+## CLI Scripts
+
+The gem ships with three executable scripts for sending and managing Slack messages
+from the command line. All three accept `-t`/`--slack-token TOKEN` and
+`-n`/`--bot-name NAME` to override the corresponding environment variables.
+Configuration can also come from `SLACK_LINE_SLACK_TOKEN` and friends as described
+above.
+
+### `slack_line_message`
+
+Sends, updates, or previews a single Slack message.
+
+```sh
+# Post a simple message
+slack_line_message --post-to "#general" --save /tmp/msg.json "Something happened!"
+
+# Preview without posting (prints JSON block kit content)
+slack_line_message "Something happened!"
+
+# Post a message using the block-kit DSL on stdin
+echo 'text "Something happened!"' | slack_line_message --post-to "#general" --save /tmp/msg.json
+
+# Append a reply to an existing thread (saved from a prior post)
+slack_line_message --append /tmp/msg.json --save /tmp/msg.json "Follow-up!"
+
+# Update a previously-sent message in place
+slack_line_message --update /tmp/msg.json "Edited message text"
+
+# Update a specific message within a saved thread (0-indexed)
+slack_line_message --update /tmp/msg.json --message-number 2 "Corrected reply"
+```
+
+Options:
+
+* `-p`/`--post-to TARGET` - channel or user to post to
+* `-a`/`--append PATH` - append a reply to the thread saved at PATH
+* `-U`/`--update PATH` - update the message (or thread) saved at PATH
+* `-m`/`--message-number N` - which message in a thread to update (0-indexed;
+  required with `--update` on a thread)
+* `-s`/`--save PATH` - write the sent/updated result to PATH as JSON
+* `-u`/`--look-up-users` - resolve `@mentions` via the Slack API
+* `--cache-path PATH` / `--cache-duration DURATION` - disk-cache user/group lookups
+* `--no-backoff` - disable per-message sleep delays
+
+When no content arguments are given and no DSL is piped, the script reads DSL
+interactively from stdin.
+
+### `slack_line_thread`
+
+Sends or previews a thread (multiple messages posted together).
+
+```sh
+# Post a thread from positional string arguments
+slack_line_thread --post-to "#general" --save /tmp/thread.json "First" "Second" "Third"
+
+# Preview the thread without posting
+slack_line_thread "First" "Second"
+
+# Post a thread from block-kit DSL on stdin
+cat thread.dsl | slack_line_thread --post-to "#general" --save /tmp/thread.json
+```
+
+A DSL block looks like:
+
+```ruby
+message "Simple first message"
+message do
+  text "Fancier second message"
+  context "with some context"
+end
+```
+
+Options mirror `slack_line_message`, minus the update/append flags:
+
+* `-p`/`--post-to TARGET` - channel or user to post to
+* `-s`/`--save PATH` - write the sent result to PATH as JSON
+* `-u`/`--look-up-users`, `--cache-path`, `--cache-duration`, `--no-backoff` -
+  same as above
+
+### `slack_line_stateful_thread`
+
+Designed for long-running processes that need to post a single status message
+and then keep it updated as state changes - for example, a deployment pipeline
+that posts `[running] Deploy started`, updates it to `[done] Deploy finished`,
+and appends replies along the way. The sent message is persisted to a file;
+subsequent invocations load and re-persist that file to know which Slack message
+to update.
+
+Messages are formatted as `[STATE] body`. The `--state` and `--message` flags each
+update their respective part independently; omitting one leaves it unchanged on update.
+
+```sh
+# Initial post - creates /tmp/deploy.json and posts "[running] Deploy started"
+slack_line_stateful_thread --path /tmp/deploy.json --post-to "#deploys" \
+  --state running --message "Deploy started"
+
+# Update the state only - becomes "[done] Deploy started"
+slack_line_stateful_thread --path /tmp/deploy.json --state done
+
+# Update the body only - becomes "[done] Deploy finished"
+slack_line_stateful_thread --path /tmp/deploy.json --message "Deploy finished"
+
+# Update both state and body - becomes "[failed] Something went wrong"
+slack_line_stateful_thread --path /tmp/deploy.json --state failed --message "Something went wrong"
+
+# Append a thread reply without changing the main message
+slack_line_stateful_thread --path /tmp/deploy.json --thread --message "Step 1 complete"
+```
+
+Options:
+
+* `--path PATH` - (required) file path used to persist the sent message between invocations
+* `-p`/`--post-to TARGET` - channel or user; required on the first call, forbidden
+  thereafter
+* `-s`/`--state STATE` - the state label shown in brackets; required on first call
+* `-m`/`--message MESSAGE` - the message body; required on first call and when using
+  `--thread`
+* `--thread` - append a reply instead of updating the main message (mutually exclusive
+  with `--state`)
 
 ## Slack App Permissions
 

--- a/bin/qa/slack_line_qa
+++ b/bin/qa/slack_line_qa
@@ -330,6 +330,14 @@ Dir.mktmpdir("slack_line_qa") do |tmpdir|
       assert result.stderr.match?(/--state/i), "error not helpful: #{result.stderr.strip}"
     end
 
+    step "--thread on initial post exits nonzero with helpful error" do
+      result = run_script(STATEFUL_THREAD_SCRIPT,
+        "--path", File.join(tmpdir, "fresh.json"),
+        "-p", public_channel, "-s", "s", "-m", "m", "--thread")
+      assert result.failure?, "expected nonzero exit, got 0"
+      assert result.stderr.match?(/--thread/i), "error not helpful: #{result.stderr.strip}"
+    end
+
     step "--thread with --state exits nonzero with helpful error" do
       result = run_script(STATEFUL_THREAD_SCRIPT,
         "--path", stateful_thread_path,

--- a/bin/qa/slack_line_qa
+++ b/bin/qa/slack_line_qa
@@ -17,6 +17,7 @@ abort "SLACK_LINE_SLACK_TOKEN is required" unless ENV["SLACK_LINE_SLACK_TOKEN"]
 
 MESSAGE_SCRIPT = File.expand_path("../slack_line_message", __dir__)
 THREAD_SCRIPT = File.expand_path("../slack_line_thread", __dir__)
+STATEFUL_THREAD_SCRIPT = File.expand_path("../slack_line_stateful_thread", __dir__)
 
 ScriptResult = Struct.new(:stdout, :stderr, :exit_status, keyword_init: true) do
   def success? = exit_status.zero?
@@ -73,6 +74,7 @@ Dir.mktmpdir("slack_line_qa") do |tmpdir|
   msg2_path = File.join(tmpdir, "msg2.json")
   msg3_path = File.join(tmpdir, "msg3.json")
   thread2_path = File.join(tmpdir, "thread2.json")
+  stateful_thread_path = File.join(tmpdir, "stateful_thread.json")
 
   # ---- slack_line_message ----
 
@@ -217,6 +219,99 @@ Dir.mktmpdir("slack_line_qa") do |tmpdir|
         "QA thread [1/1 in ##{private_channel}]: Simple thread — message 2 of 2")
       assert result.success?, "exit #{result.exit_status} — #{result.stderr.strip}"
       assert result.stderr.include?(private_channel), "stderr did not mention channel: #{result.stderr.strip}"
+    end
+  end
+
+  # ---- slack_line_stateful_thread ----
+
+  group "slack_line_stateful_thread: initial post to ##{public_channel}" do
+    step "posts and saves SentMessage JSON to disk" do
+      result = run_script(STATEFUL_THREAD_SCRIPT,
+        "--path", stateful_thread_path,
+        "-p", public_channel,
+        "-s", ":hammer_and_wrench: Building",
+        "-m", "QA stateful thread [##{public_channel}]: initial post (state updates and replies expected below)")
+      assert result.success?, "exit #{result.exit_status} — #{result.stderr.strip}"
+      assert result.stderr.include?(public_channel), "stderr did not mention channel: #{result.stderr.strip}"
+      assert File.exist?(stateful_thread_path), "--path did not create file at #{stateful_thread_path}"
+      saved = rescued { JSON.parse(File.read(stateful_thread_path)) }
+      assert saved, "saved file is not valid JSON"
+      assert saved["type"] == "message", "saved JSON has wrong type: #{saved["type"].inspect}"
+    end
+  end
+
+  group "slack_line_stateful_thread: --state update" do
+    step "updates the state segment of the initial message" do
+      result = run_script(STATEFUL_THREAD_SCRIPT,
+        "--path", stateful_thread_path,
+        "-s", ":rocket: Deploying")
+      assert result.success?, "exit #{result.exit_status} — #{result.stderr.strip}"
+      assert result.stderr.match?(/[Uu]pdated/), "stderr did not confirm update: #{result.stderr.strip}"
+      assert result.stderr.include?(public_channel), "stderr did not mention channel: #{result.stderr.strip}"
+      saved = rescued { JSON.parse(File.read(stateful_thread_path)) }
+      assert saved["type"] == "message", "path file should still be a message after state update"
+    end
+  end
+
+  group "slack_line_stateful_thread: --message append (no file update)" do
+    step "posts a reply and leaves the path file unchanged" do
+      mtime_before = File.mtime(stateful_thread_path)
+      result = run_script(STATEFUL_THREAD_SCRIPT,
+        "--path", stateful_thread_path,
+        "-m", "QA stateful thread [##{public_channel}]: --message reply (file should be unchanged)")
+      assert result.success?, "exit #{result.exit_status} — #{result.stderr.strip}"
+      assert result.stderr.match?(/[Aa]ppended/), "stderr did not confirm append: #{result.stderr.strip}"
+      assert File.mtime(stateful_thread_path) == mtime_before, "path file was modified by --message"
+    end
+  end
+
+  group "slack_line_stateful_thread: --thread reply (saves SentThread to path)" do
+    step "posts a reply and updates path file to a SentThread" do
+      result = run_script(STATEFUL_THREAD_SCRIPT,
+        "--path", stateful_thread_path,
+        "--thread",
+        "-m", "QA stateful thread [##{public_channel}]: --thread reply (file should become a thread)")
+      assert result.success?, "exit #{result.exit_status} — #{result.stderr.strip}"
+      assert result.stderr.match?(/[Tt]hreaded/), "stderr did not confirm thread: #{result.stderr.strip}"
+      saved = rescued { JSON.parse(File.read(stateful_thread_path)) }
+      assert saved, "saved file is not valid JSON"
+      assert saved["type"] == "thread", "path file should be a thread after --thread: #{saved["type"].inspect}"
+      assert saved["messages"].size == 2, "expected 2 messages in saved thread, got #{saved["messages"].size}"
+    end
+
+    step "can append a second --thread reply onto the saved SentThread" do
+      result = run_script(STATEFUL_THREAD_SCRIPT,
+        "--path", stateful_thread_path,
+        "--thread",
+        "-m", "QA stateful thread [##{public_channel}]: second --thread reply")
+      assert result.success?, "exit #{result.exit_status} — #{result.stderr.strip}"
+      saved = rescued { JSON.parse(File.read(stateful_thread_path)) }
+      assert saved["type"] == "thread", "path file should still be a thread"
+      assert saved["messages"].size == 3, "expected 3 messages in saved thread, got #{saved["messages"].size}"
+    end
+  end
+
+  group "slack_line_stateful_thread: error handling" do
+    step "missing --path exits nonzero with helpful error" do
+      result = run_script(STATEFUL_THREAD_SCRIPT, "-p", public_channel, "-s", "s", "-m", "m")
+      assert result.failure?, "expected nonzero exit, got 0"
+      assert result.stderr.match?(/--path/i), "error not helpful: #{result.stderr.strip}"
+    end
+
+    step "initial post missing --state exits nonzero with helpful error" do
+      result = run_script(STATEFUL_THREAD_SCRIPT,
+        "--path", File.join(tmpdir, "nonexistent.json"),
+        "-p", public_channel, "-m", "m")
+      assert result.failure?, "expected nonzero exit, got 0"
+      assert result.stderr.match?(/--state/i), "error not helpful: #{result.stderr.strip}"
+    end
+
+    step "--thread with --state exits nonzero with helpful error" do
+      result = run_script(STATEFUL_THREAD_SCRIPT,
+        "--path", stateful_thread_path,
+        "--thread", "-s", "s", "-m", "m")
+      assert result.failure?, "expected nonzero exit, got 0"
+      assert result.stderr.match?(/--thread|--state/i), "error not helpful: #{result.stderr.strip}"
     end
   end
 

--- a/bin/qa/slack_line_qa
+++ b/bin/qa/slack_line_qa
@@ -291,6 +291,30 @@ Dir.mktmpdir("slack_line_qa") do |tmpdir|
     end
   end
 
+  group "slack_line_stateful_thread: --state/--message update after --thread reply" do
+    step "updates the root message state while file remains a SentThread" do
+      result = run_script(STATEFUL_THREAD_SCRIPT,
+        "--path", stateful_thread_path,
+        "-s", ":white_check_mark: Complete")
+      assert result.success?, "exit #{result.exit_status} — #{result.stderr.strip}"
+      assert result.stderr.match?(/[Uu]pdated/), "stderr did not confirm update: #{result.stderr.strip}"
+      saved = rescued { JSON.parse(File.read(stateful_thread_path)) }
+      assert saved["type"] == "thread", "path file should still be a thread after state update: #{saved["type"].inspect}"
+      assert saved["messages"].size == 3, "expected 3 messages in saved thread, got #{saved["messages"].size}"
+    end
+
+    step "updates the root message body while file remains a SentThread" do
+      result = run_script(STATEFUL_THREAD_SCRIPT,
+        "--path", stateful_thread_path,
+        "-m", "QA stateful thread [##{public_channel}]: body updated after threading")
+      assert result.success?, "exit #{result.exit_status} — #{result.stderr.strip}"
+      assert result.stderr.match?(/[Uu]pdated/), "stderr did not confirm update: #{result.stderr.strip}"
+      saved = rescued { JSON.parse(File.read(stateful_thread_path)) }
+      assert saved["type"] == "thread", "path file should still be a thread after message update: #{saved["type"].inspect}"
+      assert saved["messages"].size == 3, "expected 3 messages in saved thread, got #{saved["messages"].size}"
+    end
+  end
+
   group "slack_line_stateful_thread: error handling" do
     step "missing --path exits nonzero with helpful error" do
       result = run_script(STATEFUL_THREAD_SCRIPT, "-p", public_channel, "-s", "s", "-m", "m")

--- a/bin/qa/slack_line_qa
+++ b/bin/qa/slack_line_qa
@@ -241,7 +241,7 @@ Dir.mktmpdir("slack_line_qa") do |tmpdir|
   end
 
   group "slack_line_stateful_thread: --state update" do
-    step "updates the state segment of the initial message" do
+    step "updates the state segment of the initial message and saves" do
       result = run_script(STATEFUL_THREAD_SCRIPT,
         "--path", stateful_thread_path,
         "-s", ":rocket: Deploying")
@@ -253,15 +253,15 @@ Dir.mktmpdir("slack_line_qa") do |tmpdir|
     end
   end
 
-  group "slack_line_stateful_thread: --message append (no file update)" do
-    step "posts a reply and leaves the path file unchanged" do
-      mtime_before = File.mtime(stateful_thread_path)
+  group "slack_line_stateful_thread: --message update" do
+    step "updates the body segment of the initial message and saves" do
       result = run_script(STATEFUL_THREAD_SCRIPT,
         "--path", stateful_thread_path,
-        "-m", "QA stateful thread [##{public_channel}]: --message reply (file should be unchanged)")
+        "-m", "QA stateful thread [##{public_channel}]: --message updated body")
       assert result.success?, "exit #{result.exit_status} — #{result.stderr.strip}"
-      assert result.stderr.match?(/[Aa]ppended/), "stderr did not confirm append: #{result.stderr.strip}"
-      assert File.mtime(stateful_thread_path) == mtime_before, "path file was modified by --message"
+      assert result.stderr.match?(/[Uu]pdated/), "stderr did not confirm update: #{result.stderr.strip}"
+      saved = rescued { JSON.parse(File.read(stateful_thread_path)) }
+      assert saved["type"] == "message", "path file should still be a message after --message update"
     end
   end
 

--- a/bin/slack_line_stateful_thread
+++ b/bin/slack_line_stateful_thread
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+require_relative "../lib/slack_line"
+
+begin
+  SlackLine::Cli::SlackLineStatefulThread.new(argv: ARGV).run
+rescue SlackLine::Cli::ExitException => e
+  abort e.message
+end

--- a/lib/slack_line/cli/slack_line_stateful_thread.rb
+++ b/lib/slack_line/cli/slack_line_stateful_thread.rb
@@ -1,0 +1,113 @@
+require "optparse"
+
+module SlackLine
+  module Cli
+    class SlackLineStatefulThread
+      def initialize(argv:, stdout: $stdout, stderr: $stderr)
+        @argv = argv
+        @stdout = stdout
+        @stderr = stderr
+      end
+
+      def run
+        validate_options!
+        if path_exists?
+          run_subsequent
+        else
+          run_initial
+        end
+      rescue DiskCaching::NoLightly, Configuration::InvalidValue => e
+        raise ExitException, e.message
+      end
+
+      def options
+        return @options if defined?(@options)
+        opts = {path: nil, post_to: nil, state: nil, message: nil, slack_token: nil, bot_name: nil}
+        option_parser(opts).parse(@argv.dup)
+        @options = opts
+      end
+
+      def configuration
+        return @configuration if defined?(@configuration)
+        cfg_opts = options.slice(:slack_token, :bot_name).compact
+        @configuration = Configuration.new(nil, **cfg_opts)
+      end
+
+      private
+
+      attr_reader :stdout, :stderr
+
+      def option_parser(opts) # rubocop:disable Metrics/AbcSize
+        OptionParser.new do |parser|
+          parser.on("-t", "--slack-token TOKEN") { |t| opts[:slack_token] = t }
+          parser.on("-n", "--bot-name NAME") { |n| opts[:bot_name] = n }
+          parser.on("--path PATH") { |p| opts[:path] = p }
+          parser.on("-p", "--post-to TARGET") { |t| opts[:post_to] = t }
+          parser.on("-s", "--state STATE") { |s| opts[:state] = s }
+          parser.on("-m", "--message MESSAGE") { |m| opts[:message] = m }
+        end
+      end
+
+      def validate_options!
+        raise ExitException, "--path is required" unless options[:path]
+        path_exists? ? validate_subsequent_options! : validate_initial_options!
+      end
+
+      def validate_initial_options!
+        raise ExitException, "--post-to is required for initial post" unless options[:post_to]
+        raise ExitException, "--state is required for initial post" unless options[:state]
+        raise ExitException, "--message is required for initial post" unless options[:message]
+      end
+
+      def validate_subsequent_options!
+        raise ExitException, "--post-to cannot be used after initial post" if options[:post_to]
+        if options[:state] && options[:message]
+          raise ExitException, "Only one of --state or --message can be used at a time"
+        end
+        raise ExitException, "One of --state or --message is required" unless options[:state] || options[:message]
+      end
+
+      def path_exists? = options[:path] && File.exist?(options[:path])
+
+      def client = @client ||= Client.new(configuration)
+
+      def load_sent
+        @load_sent ||= SlackLine.from_json(JSON.parse(File.read(options[:path])), client:)
+      end
+
+      def save_sent(result) = File.write(options[:path], JSON.pretty_generate(result.as_json))
+
+      def run_initial
+        text = "[#{options[:state]}] #{options[:message]}"
+        sent = Message.new(text, client:).post(to: options[:post_to])
+        save_sent(sent)
+        stderr.puts "Posted stateful thread to #{options[:post_to]}"
+      end
+
+      def run_subsequent
+        options[:state] ? run_update_state : run_append_message
+      end
+
+      def extract_body(sent)
+        text = sent.content.dig(0, "text", "text")
+        match = text&.match(/\A\[[^\]]*\] (.+)\z/m)
+        raise ExitException, "Cannot parse body from stored message content" unless match
+        match[1]
+      end
+
+      def run_update_state
+        sent = load_sent
+        new_text = "[#{options[:state]}] #{extract_body(sent)}"
+        updated = sent.update(Message.new(new_text, client:))
+        save_sent(updated)
+        stderr.puts "Updated state in #{updated.channel}"
+      end
+
+      def run_append_message
+        sent = load_sent
+        sent_thread = sent.append(options[:message])
+        stderr.puts "Appended message to thread in #{sent_thread.channel}"
+      end
+    end
+  end
+end

--- a/lib/slack_line/cli/slack_line_stateful_thread.rb
+++ b/lib/slack_line/cli/slack_line_stateful_thread.rb
@@ -55,6 +55,7 @@ module SlackLine
       end
 
       def validate_initial_options!
+        raise ExitException, "--thread cannot be used on initial post" if options[:thread]
         raise ExitException, "--post-to is required for initial post" unless options[:post_to]
         raise ExitException, "--state is required for initial post" unless options[:state]
         raise ExitException, "--message is required for initial post" unless options[:message]

--- a/lib/slack_line/cli/slack_line_stateful_thread.rb
+++ b/lib/slack_line/cli/slack_line_stateful_thread.rb
@@ -22,7 +22,7 @@ module SlackLine
 
       def options
         return @options if defined?(@options)
-        opts = {path: nil, post_to: nil, state: nil, message: nil, slack_token: nil, bot_name: nil}
+        opts = {path: nil, post_to: nil, state: nil, message: nil, thread: nil, slack_token: nil, bot_name: nil}
         option_parser(opts).parse(@argv.dup)
         @options = opts
       end
@@ -45,6 +45,7 @@ module SlackLine
           parser.on("-p", "--post-to TARGET") { |t| opts[:post_to] = t }
           parser.on("-s", "--state STATE") { |s| opts[:state] = s }
           parser.on("-m", "--message MESSAGE") { |m| opts[:message] = m }
+          parser.on("--thread") { opts[:thread] = true }
         end
       end
 
@@ -61,6 +62,15 @@ module SlackLine
 
       def validate_subsequent_options!
         raise ExitException, "--post-to cannot be used after initial post" if options[:post_to]
+        options[:thread] ? validate_thread_options! : validate_update_options!
+      end
+
+      def validate_thread_options!
+        raise ExitException, "--thread cannot be used with --state" if options[:state]
+        raise ExitException, "--thread requires --message" unless options[:message]
+      end
+
+      def validate_update_options!
         if options[:state] && options[:message]
           raise ExitException, "Only one of --state or --message can be used at a time"
         end
@@ -85,7 +95,13 @@ module SlackLine
       end
 
       def run_subsequent
-        options[:state] ? run_update_state : run_append_message
+        if options[:state]
+          run_update_state
+        elsif options[:thread]
+          run_thread_message
+        else
+          run_append_message
+        end
       end
 
       def extract_body(sent)
@@ -101,6 +117,13 @@ module SlackLine
         updated = sent.update(Message.new(new_text, client:))
         save_sent(updated)
         stderr.puts "Updated state in #{updated.channel}"
+      end
+
+      def run_thread_message
+        sent = load_sent
+        sent_thread = sent.append(options[:message])
+        save_sent(sent_thread)
+        stderr.puts "Threaded message in #{sent_thread.channel}"
       end
 
       def run_append_message

--- a/lib/slack_line/cli/slack_line_stateful_thread.rb
+++ b/lib/slack_line/cli/slack_line_stateful_thread.rb
@@ -71,9 +71,6 @@ module SlackLine
       end
 
       def validate_update_options!
-        if options[:state] && options[:message]
-          raise ExitException, "Only one of --state or --message can be used at a time"
-        end
         raise ExitException, "One of --state or --message is required" unless options[:state] || options[:message]
       end
 
@@ -95,28 +92,26 @@ module SlackLine
       end
 
       def run_subsequent
-        if options[:state]
-          run_update_state
-        elsif options[:thread]
-          run_thread_message
-        else
-          run_append_message
-        end
+        options[:thread] ? run_thread_message : run_update_message
       end
 
-      def extract_body(sent)
-        text = sent.content.dig(0, "text", "text")
-        match = text&.match(/\A\[[^\]]*\] (.+)\z/m)
-        raise ExitException, "Cannot parse body from stored message content" unless match
-        match[1]
+      def parse_state_message(text)
+        match = text&.match(/\A\[([^\]]*)\] (.+)\z/m)
+        raise ExitException, "Cannot parse state and body from stored message content" unless match
+        [match[1], match[2]]
       end
 
-      def run_update_state
+      def current_state_and_body(sent)
+        parse_state_message(sent.content.dig(0, "text", "text"))
+      end
+
+      def run_update_message
         sent = load_sent
-        new_text = "[#{options[:state]}] #{extract_body(sent)}"
+        current_state, current_body = current_state_and_body(sent)
+        new_text = "[#{options[:state] || current_state}] #{options[:message] || current_body}"
         updated = sent.update(Message.new(new_text, client:))
         save_sent(updated)
-        stderr.puts "Updated state in #{updated.channel}"
+        stderr.puts "Updated message in #{updated.channel}"
       end
 
       def run_thread_message
@@ -124,12 +119,6 @@ module SlackLine
         sent_thread = sent.append(options[:message])
         save_sent(sent_thread)
         stderr.puts "Threaded message in #{sent_thread.channel}"
-      end
-
-      def run_append_message
-        sent = load_sent
-        sent_thread = sent.append(options[:message])
-        stderr.puts "Appended message to thread in #{sent_thread.channel}"
       end
     end
   end

--- a/lib/slack_line/sent_thread.rb
+++ b/lib/slack_line/sent_thread.rb
@@ -10,8 +10,13 @@ module SlackLine
     attr_reader :sent_messages
     alias_method :messages, :sent_messages
     def_delegators :sent_messages, :each, :map, :size, :first, :last, :empty?
-    def_delegators :first, :channel, :ts
+    def_delegators :first, :channel, :ts, :content
     alias_method :thread_ts, :ts
+
+    def update(*text_or_blocks, &dsl_block)
+      updated_root = first.update(*text_or_blocks, &dsl_block)
+      SentThread.new(updated_root, *sent_messages[1..])
+    end
 
     def append(*text_or_blocks, &dsl_block)
       extended = first.append(*text_or_blocks, &dsl_block)

--- a/spec/slack_line/cli/slack_line_stateful_thread_spec.rb
+++ b/spec/slack_line/cli/slack_line_stateful_thread_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe SlackLine::Cli::SlackLineStatefulThread do
           expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, /--message is required/)
         end
       end
+
+      context "when --thread is given" do
+        let(:argv) { %w[--slack-token fake --path /tmp/thread.json --post-to C12345678 --state building --message hello --thread] }
+
+        it "raises ExitException" do
+          expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, /--thread cannot be used on initial post/)
+        end
+      end
     end
 
     context "for subsequent calls (file exists at path)" do

--- a/spec/slack_line/cli/slack_line_stateful_thread_spec.rb
+++ b/spec/slack_line/cli/slack_line_stateful_thread_spec.rb
@@ -70,14 +70,6 @@ RSpec.describe SlackLine::Cli::SlackLineStatefulThread do
         end
       end
 
-      context "when both --state and --message are given" do
-        let(:argv) { %w[--slack-token fake --path /tmp/thread.json --state deploying --message hello] }
-
-        it "raises ExitException" do
-          expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, /Only one of --state or --message/)
-        end
-      end
-
       context "when neither --state nor --message is given" do
         let(:argv) { %w[--slack-token fake --path /tmp/thread.json] }
 
@@ -166,34 +158,56 @@ RSpec.describe SlackLine::Cli::SlackLineStatefulThread do
     end
   end
 
-  describe "subsequent --message append (file exists)" do
+  describe "subsequent --message update (file exists)" do
     let(:argv) { %w[--slack-token fake --path /tmp/thread.json --message Pipeline\ complete] }
 
     before do
       allow(File).to receive(:exist?).with("/tmp/thread.json").and_return(true)
       allow(File).to receive(:read).with("/tmp/thread.json").and_return(persisted_message_json)
-      allow(slack_client).to receive(:chat_postMessage).and_return(reply_response)
+      allow(File).to receive(:write)
+      allow(slack_client).to receive(:chat_update).and_return(updated_response)
     end
 
-    it "posts a reply into the thread" do
+    it "updates the initial message with the new body and preserved state" do
       cli.run
-      expect(slack_client).to have_received(:chat_postMessage).with(
-        channel: "C12345678",
-        blocks: [{type: "section", text: {type: "mrkdwn", text: "Pipeline complete"}}],
-        thread_ts: "111.000001",
-        username: nil
+      expect(slack_client).to have_received(:chat_update).with(
+        channel: "C12345678", ts: "111.000001",
+        blocks: [{type: "section", text: {type: "mrkdwn", text: "[:hammer_and_wrench: Building] Pipeline complete"}}]
       )
     end
 
-    it "does not update the path file" do
-      allow(File).to receive(:write)
+    it "saves the updated SentMessage JSON to the path" do
       cli.run
-      expect(File).not_to have_received(:write)
+      expect(File).to have_received(:write).with("/tmp/thread.json", include('"type": "message"'))
     end
 
     it "reports to stderr" do
       cli.run
       expect(stderr.string).to include("C12345678")
+    end
+  end
+
+  describe "subsequent --state and --message together (file exists)" do
+    let(:argv) { %w[--slack-token fake --path /tmp/thread.json --state :rocket:\ Deploying --message Pipeline\ complete] }
+
+    before do
+      allow(File).to receive(:exist?).with("/tmp/thread.json").and_return(true)
+      allow(File).to receive(:read).with("/tmp/thread.json").and_return(persisted_message_json)
+      allow(File).to receive(:write)
+      allow(slack_client).to receive(:chat_update).and_return(updated_response)
+    end
+
+    it "updates the initial message with both the new state and new body" do
+      cli.run
+      expect(slack_client).to have_received(:chat_update).with(
+        channel: "C12345678", ts: "111.000001",
+        blocks: [{type: "section", text: {type: "mrkdwn", text: "[:rocket: Deploying] Pipeline complete"}}]
+      )
+    end
+
+    it "saves the updated SentMessage JSON to the path" do
+      cli.run
+      expect(File).to have_received(:write).with("/tmp/thread.json", include('"type": "message"'))
     end
   end
 

--- a/spec/slack_line/cli/slack_line_stateful_thread_spec.rb
+++ b/spec/slack_line/cli/slack_line_stateful_thread_spec.rb
@@ -85,6 +85,22 @@ RSpec.describe SlackLine::Cli::SlackLineStatefulThread do
           expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, /One of --state or --message is required/)
         end
       end
+
+      context "when --thread is given with --state" do
+        let(:argv) { %w[--slack-token fake --path /tmp/thread.json --thread --state deploying --message hello] }
+
+        it "raises ExitException" do
+          expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, /--thread cannot be used with --state/)
+        end
+      end
+
+      context "when --thread is given without --message" do
+        let(:argv) { %w[--slack-token fake --path /tmp/thread.json --thread] }
+
+        it "raises ExitException" do
+          expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, /--thread requires --message/)
+        end
+      end
     end
   end
 
@@ -178,6 +194,68 @@ RSpec.describe SlackLine::Cli::SlackLineStatefulThread do
     it "reports to stderr" do
       cli.run
       expect(stderr.string).to include("C12345678")
+    end
+  end
+
+  describe "subsequent --thread --message (file exists)" do
+    let(:argv) { %w[--slack-token fake --path /tmp/thread.json --thread --message Pipeline\ complete] }
+
+    before do
+      allow(File).to receive(:exist?).with("/tmp/thread.json").and_return(true)
+      allow(File).to receive(:read).with("/tmp/thread.json").and_return(persisted_message_json)
+      allow(File).to receive(:write)
+      allow(slack_client).to receive(:chat_postMessage).and_return(reply_response)
+    end
+
+    it "posts a reply into the thread" do
+      cli.run
+      expect(slack_client).to have_received(:chat_postMessage).with(
+        channel: "C12345678",
+        blocks: [{type: "section", text: {type: "mrkdwn", text: "Pipeline complete"}}],
+        thread_ts: "111.000001",
+        username: nil
+      )
+    end
+
+    it "saves the resulting SentThread JSON to the path" do
+      cli.run
+      expect(File).to have_received(:write).with("/tmp/thread.json", include('"type": "thread"'))
+    end
+
+    it "reports to stderr" do
+      cli.run
+      expect(stderr.string).to include("C12345678")
+    end
+
+    context "when the file already contains a SentThread" do
+      let(:persisted_thread_json) do
+        JSON.generate(
+          type: "thread",
+          messages: [
+            {type: "message", ts: "111.000001", channel: "C12345678", thread_ts: nil,
+             content: [{"type" => "section", "text" => {"type" => "mrkdwn", "text" => "[:building:] Start"}}], priorly: nil},
+            {type: "message", ts: "111.000002", channel: "C12345678", thread_ts: "111.000001",
+             content: [{"type" => "section", "text" => {"type" => "mrkdwn", "text" => "First reply"}}], priorly: nil}
+          ]
+        )
+      end
+
+      before { allow(File).to receive(:read).with("/tmp/thread.json").and_return(persisted_thread_json) }
+
+      it "appends to the existing thread" do
+        cli.run
+        expect(slack_client).to have_received(:chat_postMessage).with(
+          channel: "C12345678",
+          blocks: anything,
+          thread_ts: "111.000001",
+          username: nil
+        )
+      end
+
+      it "saves the updated SentThread JSON to the path" do
+        cli.run
+        expect(File).to have_received(:write).with("/tmp/thread.json", include('"type": "thread"'))
+      end
     end
   end
 

--- a/spec/slack_line/cli/slack_line_stateful_thread_spec.rb
+++ b/spec/slack_line/cli/slack_line_stateful_thread_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe SlackLine::Cli::SlackLineStatefulThread do
     )
   end
 
+  let(:persisted_thread_json) do
+    JSON.generate(
+      type: "thread",
+      messages: [
+        {type: "message", ts: "111.000001", channel: "C12345678", thread_ts: nil, priorly: nil,
+         content: [{"type" => "section", "text" => {"type" => "mrkdwn", "text" => "[:hammer_and_wrench: Building] Deploy v1.2.3"}}]},
+        {type: "message", ts: "222.000001", channel: "C12345678", thread_ts: "111.000001", priorly: nil,
+         content: [{"type" => "section", "text" => {"type" => "mrkdwn", "text" => "First reply"}}]}
+      ]
+    )
+  end
+
   describe "validation" do
     context "when --path is not given" do
       let(:argv) { %w[--slack-token fake --post-to C12345678 --state building --message hello] }
@@ -156,6 +168,23 @@ RSpec.describe SlackLine::Cli::SlackLineStatefulThread do
       cli.run
       expect(stderr.string).to include("C12345678")
     end
+
+    context "when the file contains a SentThread" do
+      before { allow(File).to receive(:read).with("/tmp/thread.json").and_return(persisted_thread_json) }
+
+      it "updates the root message with the new state and preserved body" do
+        cli.run
+        expect(slack_client).to have_received(:chat_update).with(
+          channel: "C12345678", ts: "111.000001",
+          blocks: [{type: "section", text: {type: "mrkdwn", text: "[:rocket: Deploying] Deploy v1.2.3"}}]
+        )
+      end
+
+      it "saves the result as a SentThread" do
+        cli.run
+        expect(File).to have_received(:write).with("/tmp/thread.json", include('"type": "thread"'))
+      end
+    end
   end
 
   describe "subsequent --message update (file exists)" do
@@ -185,6 +214,23 @@ RSpec.describe SlackLine::Cli::SlackLineStatefulThread do
       cli.run
       expect(stderr.string).to include("C12345678")
     end
+
+    context "when the file contains a SentThread" do
+      before { allow(File).to receive(:read).with("/tmp/thread.json").and_return(persisted_thread_json) }
+
+      it "updates the root message with the new body and preserved state" do
+        cli.run
+        expect(slack_client).to have_received(:chat_update).with(
+          channel: "C12345678", ts: "111.000001",
+          blocks: [{type: "section", text: {type: "mrkdwn", text: "[:hammer_and_wrench: Building] Pipeline complete"}}]
+        )
+      end
+
+      it "saves the result as a SentThread" do
+        cli.run
+        expect(File).to have_received(:write).with("/tmp/thread.json", include('"type": "thread"'))
+      end
+    end
   end
 
   describe "subsequent --state and --message together (file exists)" do
@@ -208,6 +254,23 @@ RSpec.describe SlackLine::Cli::SlackLineStatefulThread do
     it "saves the updated SentMessage JSON to the path" do
       cli.run
       expect(File).to have_received(:write).with("/tmp/thread.json", include('"type": "message"'))
+    end
+
+    context "when the file contains a SentThread" do
+      before { allow(File).to receive(:read).with("/tmp/thread.json").and_return(persisted_thread_json) }
+
+      it "updates the root message with both the new state and new body" do
+        cli.run
+        expect(slack_client).to have_received(:chat_update).with(
+          channel: "C12345678", ts: "111.000001",
+          blocks: [{type: "section", text: {type: "mrkdwn", text: "[:rocket: Deploying] Pipeline complete"}}]
+        )
+      end
+
+      it "saves the result as a SentThread" do
+        cli.run
+        expect(File).to have_received(:write).with("/tmp/thread.json", include('"type": "thread"'))
+      end
     end
   end
 

--- a/spec/slack_line/cli/slack_line_stateful_thread_spec.rb
+++ b/spec/slack_line/cli/slack_line_stateful_thread_spec.rb
@@ -1,0 +1,209 @@
+RSpec.describe SlackLine::Cli::SlackLineStatefulThread do
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+
+  let(:slack_client) { instance_double(Slack::Web::Client) }
+  let(:posted_response) { Slack::Messages::Message.new({ts: "111.000001", channel: "C12345678"}) }
+  let(:updated_response) { Slack::Messages::Message.new({ts: "111.000001", channel: "C12345678"}) }
+  let(:reply_response) { Slack::Messages::Message.new({ts: "222.000001", channel: "C12345678", thread_ts: "111.000001"}) }
+
+  subject(:cli) { described_class.new(argv:, stdout:, stderr:) }
+
+  before { allow(Slack::Web::Client).to receive(:new).and_return(slack_client) }
+
+  let(:persisted_message_json) do
+    JSON.generate(
+      type: "message", ts: "111.000001", channel: "C12345678",
+      thread_ts: nil, priorly: nil,
+      content: [{"type" => "section", "text" => {"type" => "mrkdwn", "text" => "[:hammer_and_wrench: Building] Deploy v1.2.3"}}]
+    )
+  end
+
+  describe "validation" do
+    context "when --path is not given" do
+      let(:argv) { %w[--slack-token fake --post-to C12345678 --state building --message hello] }
+
+      it "raises ExitException" do
+        expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, /--path is required/)
+      end
+    end
+
+    context "for initial post (no file at path)" do
+      before { allow(File).to receive(:exist?).with("/tmp/thread.json").and_return(false) }
+
+      context "when --post-to is missing" do
+        let(:argv) { %w[--slack-token fake --path /tmp/thread.json --state building --message hello] }
+
+        it "raises ExitException" do
+          expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, /--post-to is required/)
+        end
+      end
+
+      context "when --state is missing" do
+        let(:argv) { %w[--slack-token fake --path /tmp/thread.json --post-to C12345678 --message hello] }
+
+        it "raises ExitException" do
+          expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, /--state is required/)
+        end
+      end
+
+      context "when --message is missing" do
+        let(:argv) { %w[--slack-token fake --path /tmp/thread.json --post-to C12345678 --state building] }
+
+        it "raises ExitException" do
+          expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, /--message is required/)
+        end
+      end
+    end
+
+    context "for subsequent calls (file exists at path)" do
+      before do
+        allow(File).to receive(:exist?).with("/tmp/thread.json").and_return(true)
+        allow(File).to receive(:read).with("/tmp/thread.json").and_return(persisted_message_json)
+      end
+
+      context "when --post-to is given" do
+        let(:argv) { %w[--slack-token fake --path /tmp/thread.json --post-to C99999999 --state deploying] }
+
+        it "raises ExitException" do
+          expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, /--post-to cannot be used after initial post/)
+        end
+      end
+
+      context "when both --state and --message are given" do
+        let(:argv) { %w[--slack-token fake --path /tmp/thread.json --state deploying --message hello] }
+
+        it "raises ExitException" do
+          expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, /Only one of --state or --message/)
+        end
+      end
+
+      context "when neither --state nor --message is given" do
+        let(:argv) { %w[--slack-token fake --path /tmp/thread.json] }
+
+        it "raises ExitException" do
+          expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, /One of --state or --message is required/)
+        end
+      end
+    end
+  end
+
+  describe "initial post (no file at path)" do
+    let(:argv) do
+      %w[--slack-token fake --path /tmp/thread.json --post-to C12345678
+        --state :hammer_and_wrench:\ Building --message Deploy\ v1.2.3]
+    end
+
+    before do
+      allow(File).to receive(:exist?).with("/tmp/thread.json").and_return(false)
+      allow(File).to receive(:write)
+      allow(slack_client).to receive(:chat_postMessage).and_return(posted_response)
+    end
+
+    it "posts a message with the state and message combined" do
+      cli.run
+      expect(slack_client).to have_received(:chat_postMessage).with(
+        channel: "C12345678",
+        blocks: [{type: "section", text: {type: "mrkdwn", text: "[:hammer_and_wrench: Building] Deploy v1.2.3"}}],
+        thread_ts: nil,
+        username: nil
+      )
+    end
+
+    it "saves the SentMessage JSON to the path" do
+      cli.run
+      expect(File).to have_received(:write).with("/tmp/thread.json", include('"type": "message"'))
+    end
+
+    it "reports to stderr" do
+      cli.run
+      expect(stderr.string).to include("C12345678")
+    end
+  end
+
+  describe "subsequent --state update (file exists)" do
+    let(:argv) { %w[--slack-token fake --path /tmp/thread.json --state :rocket:\ Deploying] }
+
+    before do
+      allow(File).to receive(:exist?).with("/tmp/thread.json").and_return(true)
+      allow(File).to receive(:read).with("/tmp/thread.json").and_return(persisted_message_json)
+      allow(File).to receive(:write)
+      allow(slack_client).to receive(:chat_update).and_return(updated_response)
+    end
+
+    it "updates the message with the new state and preserved body" do
+      cli.run
+      expect(slack_client).to have_received(:chat_update).with(
+        channel: "C12345678", ts: "111.000001",
+        blocks: [{type: "section", text: {type: "mrkdwn", text: "[:rocket: Deploying] Deploy v1.2.3"}}]
+      )
+    end
+
+    it "saves the updated SentMessage JSON to the path" do
+      cli.run
+      expect(File).to have_received(:write).with("/tmp/thread.json", include('"type": "message"'))
+    end
+
+    it "reports to stderr" do
+      cli.run
+      expect(stderr.string).to include("C12345678")
+    end
+  end
+
+  describe "subsequent --message append (file exists)" do
+    let(:argv) { %w[--slack-token fake --path /tmp/thread.json --message Pipeline\ complete] }
+
+    before do
+      allow(File).to receive(:exist?).with("/tmp/thread.json").and_return(true)
+      allow(File).to receive(:read).with("/tmp/thread.json").and_return(persisted_message_json)
+      allow(slack_client).to receive(:chat_postMessage).and_return(reply_response)
+    end
+
+    it "posts a reply into the thread" do
+      cli.run
+      expect(slack_client).to have_received(:chat_postMessage).with(
+        channel: "C12345678",
+        blocks: [{type: "section", text: {type: "mrkdwn", text: "Pipeline complete"}}],
+        thread_ts: "111.000001",
+        username: nil
+      )
+    end
+
+    it "does not update the path file" do
+      allow(File).to receive(:write)
+      cli.run
+      expect(File).not_to have_received(:write)
+    end
+
+    it "reports to stderr" do
+      cli.run
+      expect(stderr.string).to include("C12345678")
+    end
+  end
+
+  describe "when DiskCaching::NoLightly is raised" do
+    let(:argv) { %w[--slack-token fake --path /tmp/thread.json --post-to C12345678 --state s --message m] }
+
+    before do
+      allow(File).to receive(:exist?).with("/tmp/thread.json").and_return(false)
+      allow(cli).to receive(:run_initial).and_raise(SlackLine::DiskCaching::NoLightly, "lightly gem required")
+    end
+
+    it "raises ExitException" do
+      expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, "lightly gem required")
+    end
+  end
+
+  describe "when Configuration::InvalidValue is raised" do
+    let(:argv) { %w[--slack-token fake --path /tmp/thread.json --post-to C12345678 --state s --message m] }
+
+    before do
+      allow(File).to receive(:exist?).with("/tmp/thread.json").and_return(false)
+      allow(cli).to receive(:run_initial).and_raise(SlackLine::Configuration::InvalidValue, "invalid duration")
+    end
+
+    it "raises ExitException" do
+      expect { cli.run }.to raise_error(SlackLine::Cli::ExitException, "invalid duration")
+    end
+  end
+end

--- a/spec/slack_line/sent_thread_spec.rb
+++ b/spec/slack_line/sent_thread_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe SlackLine::SentThread do
-  let(:sent_message_one) { instance_double(SlackLine::SentMessage, channel: "C12345678", ts: "1234567890.123456") }
+  let(:root_content) { [{"type" => "section", "text" => {"type" => "mrkdwn", "text" => "root message"}}] }
+  let(:sent_message_one) { instance_double(SlackLine::SentMessage, channel: "C12345678", ts: "1234567890.123456", content: root_content) }
   let(:sent_message_two) { instance_double(SlackLine::SentMessage, channel: "C12345678", ts: "1234567891.654321") }
   let(:sent_message_tre) { instance_double(SlackLine::SentMessage, channel: "C12345678", ts: "1234567894.111111") }
   let(:sent_messages) { [sent_message_one, sent_message_two, sent_message_tre] }
@@ -8,6 +9,7 @@ RSpec.describe SlackLine::SentThread do
 
   it { is_expected.to have_attributes(messages: sent_messages, sent_messages:) }
   it { is_expected.to have_attributes(channel: "C12345678", ts: "1234567890.123456", thread_ts: "1234567890.123456") }
+  it { is_expected.to have_attributes(content: root_content) }
 
   it "behaves like an Enumerable" do
     expect(sent_thread.size).to eq(3)
@@ -83,47 +85,52 @@ RSpec.describe SlackLine::SentThread do
     end
   end
 
-  describe "#as_json" do
-    let(:msg_one_json) { {"type" => "message", "ts" => "1234567890.123456", "channel" => "C12345678", "thread_ts" => nil, "content" => [], "priorly" => nil} }
-    let(:msg_two_json) { {"type" => "message", "ts" => "1234567891.654321", "channel" => "C12345678", "thread_ts" => "1234567890.123456", "content" => [], "priorly" => nil} }
-    let(:msg_tre_json) { {"type" => "message", "ts" => "1234567894.111111", "channel" => "C12345678", "thread_ts" => "1234567890.123456", "content" => [], "priorly" => nil} }
+  describe "#update" do
+    let(:updated_root) { instance_double(SlackLine::SentMessage, channel: "C12345678", ts: "1234567890.123456") }
 
-    before do
-      allow(sent_message_one).to receive(:as_json).and_return(msg_one_json)
-      allow(sent_message_two).to receive(:as_json).and_return(msg_two_json)
-      allow(sent_message_tre).to receive(:as_json).and_return(msg_tre_json)
+    context "when updating with a string" do
+      before { allow(sent_message_one).to receive(:update).with("Updated text").and_return(updated_root) }
+      subject(:result) { sent_thread.update("Updated text") }
+
+      it "delegates to first.update" do
+        result
+        expect(sent_message_one).to have_received(:update).with("Updated text")
+      end
+
+      it "returns a SentThread with the updated root and all reply messages" do
+        expect(result).to be_a(SlackLine::SentThread)
+        expect(result.sent_messages).to eq([updated_root, sent_message_two, sent_message_tre])
+      end
     end
 
-    it "returns a hash with type 'thread' and serialized messages" do
-      expect(sent_thread.as_json).to eq(
-        "type" => "thread",
-        "messages" => [msg_one_json, msg_two_json, msg_tre_json]
-      )
-    end
-  end
+    context "when updating with a Message object" do
+      let(:client) { instance_double(SlackLine::Client) }
+      let(:message) { SlackLine::Message.new("Updated content", client:) }
+      before { allow(sent_message_one).to receive(:update).with(message).and_return(updated_root) }
+      subject(:result) { sent_thread.update(message) }
 
-  describe ".from_json" do
-    let(:client) { instance_double(SlackLine::Client) }
-    let(:data) do
-      {
-        "type" => "thread",
-        "messages" => [
-          {"type" => "message", "ts" => "1234567890.123456", "channel" => "C12345678", "thread_ts" => nil, "content" => [], "priorly" => nil},
-          {"type" => "message", "ts" => "1234567891.654321", "channel" => "C12345678", "thread_ts" => "1234567890.123456", "content" => [], "priorly" => nil}
-        ]
-      }
+      it "delegates to first.update with the Message object" do
+        result
+        expect(sent_message_one).to have_received(:update).with(message)
+      end
+
+      it "returns a SentThread with the updated root and all reply messages" do
+        expect(result.sent_messages).to eq([updated_root, sent_message_two, sent_message_tre])
+      end
     end
 
-    subject(:loaded) { described_class.from_json(data, client:) }
+    context "when updating with a DSL block" do
+      before { allow(sent_message_one).to receive(:update).and_return(updated_root) }
+      subject(:result) { sent_thread.update { text "DSL content" } }
 
-    it "returns a SentThread" do
-      expect(loaded).to be_a(described_class)
-    end
+      it "delegates the block to first.update" do
+        result
+        expect(sent_message_one).to have_received(:update)
+      end
 
-    it "restores each message with the correct ts and channel" do
-      expect(loaded.size).to eq(2)
-      expect(loaded.first).to have_attributes(ts: "1234567890.123456", channel: "C12345678")
-      expect(loaded.last).to have_attributes(ts: "1234567891.654321", thread_ts: "1234567890.123456")
+      it "returns a SentThread with the updated root and all reply messages" do
+        expect(result.sent_messages).to eq([updated_root, sent_message_two, sent_message_tre])
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #11 

This script makes it convenient to create, update, and append to a single slack thread from a persistent process. My target use-case is a CD master build:

* Create the message when the build starts, like `[🏗️ building] Release abcd1234 by @foo: Fram the Jumbiston carefully`
* Update it as the build passes through phases:
  - `[🧪 testing] Release abcd1234....`
  - `[🚀 deploying] Release abcd1234...`
  - `[✅ complete] Release abcd1234...`
  - Or if it reaches a failure state, `[❌ failed] Release abcd1234....`
* Add messages to the _thread_ (to avoid cluttering the channel) as each job fails, or in some cases succeeds:
  - `All builds completed after 7:03`
  - `Ruby Unit Tests failed on container 8`
  - `Deploys in progress: monolith, foo_service, bar_service`
  - `Failure encountered: "Could not fetch container ______ from dockerhub"`
* Update the readme to describe all three scripts in a new section, since they're intended for use.

In order to work with the same thread/message, we'll need to persist the artifact from job to job - in Circle/Github, that can be done with caches that include the current workflow ID in their keys (there are several ways really in github. And an s3 sidecar is a solid solution in almost any context).